### PR TITLE
bump Savon

### DIFF
--- a/gus_bir1.gemspec
+++ b/gus_bir1.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'simplecov'
 
-  spec.add_dependency 'savon', '~> 2.12'
+  spec.add_dependency 'savon', '~> 2.14'
   spec.add_dependency 'savon-multipart--feb-2019', '~> 2.1', '>= 2.1.2'
 end

--- a/lib/gus_bir1/client.rb
+++ b/lib/gus_bir1/client.rb
@@ -85,7 +85,7 @@ module GusBir1
 
     def method_missing(method, *args)
       if savon_client.operations.include? method
-        response_hash = call(method, args[0]).hash
+        response_hash = call(method, args[0]).full_hash
         response_hash.dig(:envelope, :body, "#{method}_response".to_sym, "#{method}_result".to_sym)
       else
         super


### PR DESCRIPTION
2.14.0 (2022-12-16)
BC BREAKING Fix: [#985](https://redirect.github.com/savonrb/savon/pull/985) Renamed `Savon::Response#hash` to `Savon::Response#full_hash`
BC BREAKING Fix: [#988](https://redirect.github.com/savonrb/savon/pull/988) Savon no longer monkeypatches String#snakecase
Fix: [#989](https://redirect.github.com/savonrb/savon/pull/989) Do not include xmlns from WSDL, which breaks some servers